### PR TITLE
Update javalin to 4.0.0-ALPHA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation "org.jetbrains.exposed:exposed-dao:0.29.1"
     implementation "org.jetbrains.exposed:exposed-jdbc:0.29.1"
     implementation 'org.jetbrains.exposed:exposed-java-time:0.29.1'
-    implementation 'io.javalin:javalin:3.8.0'
+    implementation 'io.javalin:javalin:4.0.0.ALPHA0'
     implementation "org.slf4j:slf4j-simple:1.8.0-beta4"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.10.3"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0"

--- a/src/main/kotlin/controllers/MachineController.kt
+++ b/src/main/kotlin/controllers/MachineController.kt
@@ -1,6 +1,7 @@
 package controllers
 
 import io.javalin.http.Context
+import io.javalin.http.context.body
 import models.Machine
 import models.MachineContainer
 import services.MachineService

--- a/src/main/kotlin/controllers/MaintenanceController.kt
+++ b/src/main/kotlin/controllers/MaintenanceController.kt
@@ -1,6 +1,7 @@
 package controllers
 
 import io.javalin.http.Context
+import io.javalin.http.context.body
 import models.Maintenance
 import models.MaintenanceContainer
 import services.MaintenanceService

--- a/src/main/kotlin/controllers/UserController.kt
+++ b/src/main/kotlin/controllers/UserController.kt
@@ -1,6 +1,7 @@
 package controllers
 
 import io.javalin.http.Context
+import io.javalin.http.context.body
 import models.Constants
 import models.User
 import services.UserService

--- a/src/test/kotlin/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/controllers/UserControllerTest.kt
@@ -1,12 +1,12 @@
 package controllers
 
-import com.nhaarman.mockitokotlin2.verify
 import exceptions.IllegalUserException
 import helpers.TestDatabase
 import io.javalin.http.Context
 import io.javalin.http.context.body
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import models.Constants
 import models.User
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/src/test/kotlin/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/controllers/UserControllerTest.kt
@@ -1,21 +1,18 @@
 package controllers
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import exceptions.IllegalUserException
 import helpers.TestDatabase
 import io.javalin.http.Context
+import io.javalin.http.context.body
+import io.mockk.every
+import io.mockk.mockk
 import models.Constants
 import models.User
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import services.UserService
 
 class UserControllerTest {
@@ -26,16 +23,15 @@ class UserControllerTest {
 
     @AfterEach
     fun tearDown() {
-        Mockito.framework().clearInlineMocks()
         TestDatabase.purge()
     }
 
     @Test
     fun `loginUser() throws an exception if unsuccessful`() {
-        val context = mock<Context>()
+        val context = mockk<Context>(relaxed = true)
         val user = User(username = "TEST", password = "TEST")
 
-        whenever(context.body<User>()).thenReturn(user)
+        every { context.body<User>() } returns user
 
         assertThatThrownBy {
             UserController.loginUser(context)
@@ -44,33 +40,33 @@ class UserControllerTest {
 
     @Test
     fun `loginUser() writes to cookie`() {
-        val context = mock<Context>()
+        val context = mockk<Context>(relaxed = true)
         val user = User(username = "TEST", password = "TEST", email = "test@mail.com")
         UserService.createUser(user)
         UserService.approveUser(user.username!!)
 
-        whenever(context.body<User>()).thenReturn(user)
-        whenever(context.host()).doReturn("localhost")
+        every { context.body<User>() } returns user
+        every { context.url() } returns "http://localhost"
 
         UserController.loginUser(context)
 
-        verify(context).cookie(eq(Constants.USER_TOKEN.name), any(), any())
-        verify(context).cookie(eq(Constants.USER_NAME.name), eq(user.username!!), any())
-        verify(context).json(any<User>())
+        verify { context.cookie(Constants.USER_TOKEN.name, any()) }
+        verify { context.cookie(Constants.USER_NAME.name, user.username!!) }
+        verify { context.json(any<User>()) }
     }
 
     @Test
     fun `logoutUser() removes cookies`() {
-        val context = mock<Context>()
+        val context = mockk<Context>(relaxed = true)
 
-        whenever(context.host()).doReturn("localhost")
+        every { context.url() } returns "http://localhost"
 
         context.cookie(Constants.USER_TOKEN.name, "TOKEN")
         context.cookie(Constants.USER_NAME.name, "USER")
 
         UserController.logoutUser(context)
 
-        verify(context).removeCookie(eq(Constants.USER_TOKEN.name), eq("/"))
-        verify(context).removeCookie(eq(Constants.USER_NAME.name), eq("/"))
+        verify { context.removeCookie(Constants.USER_TOKEN.name, "/") }
+        verify { context.removeCookie(Constants.USER_NAME.name, "/") }
     }
 }

--- a/src/test/kotlin/services/UserServiceTest.kt
+++ b/src/test/kotlin/services/UserServiceTest.kt
@@ -282,7 +282,7 @@ class UserServiceTest {
 
         assertThat(UserService.getUsers().size).isEqualTo(3)
         UserService.getUsers().forEach {
-            assertThat(it).isEqualTo(User(username = it.username, email = it.email, password = null, isApproved = false, role = UserRole.NON_ADMIN, createdAt = it!!.createdAt))
+            assertThat(it).isEqualTo(User(username = it.username, email = it.email, password = null, isApproved = false, role = UserRole.NON_ADMIN, createdAt = it.createdAt))
         }
     }
 


### PR DESCRIPTION
- Helps with mocking `context` in tests.
- Fixes framework's security holes.

More info: https://javalin.io/news/2021/02/17/javalin-4.0.0-alpha.html